### PR TITLE
feature/create-debug-router-command

### DIFF
--- a/bin/neo
+++ b/bin/neo
@@ -3,31 +3,38 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+use Neo\App;
 use Neo\Core\Console\ConsoleHandler;
 use Neo\Core\DI\Container;
 
 define('ROOT_DIR', dirname(__DIR__) . '/');
 
-$container = new Container();
-$container->set(Container::class, fn() => $container);
-$basePath = realpath(__DIR__ . '/../');
-
 global $argv;
+
+$basePath = realpath(__DIR__ . '/../');
+$project  = null;
 
 foreach ($argv as $arg) {
     if (str_starts_with($arg, '--project=')) {
         $project = substr($arg, 10);
-        $srcPath = $basePath . '/src/' . $project;
-
-        $container->set('application', $project);
-        $container->set('cronsPath',   $srcPath . '/App/Crons');
-        $container->set('storagePath', $srcPath . '/Storage');
-        $container->set('configsPath', $srcPath . '/Config');
+        break;
     }
 }
 
-$container->set('basePath', $basePath);
-$container->set('srcPath', $basePath . '/src');
+if ($project !== null && !is_dir($basePath . '/src/' . $project)) {
+    echo "\033[31m✘ Project '$project' not found in src/.\033[0m\n";
+    exit(1);
+}
+
+if ($project !== null) {
+    $app       = new App();
+    $container = $app->getContainer();
+} else {
+    $container = new Container();
+    $container->set(Container::class, fn() => $container);
+    $container->set('basePath', $basePath);
+    $container->set('srcPath',  $basePath . '/src');
+}
 
 $console = new ConsoleHandler($container);
 $console->run($argv);

--- a/neo/Core/Console/Commands/DebugRouterCommand.php
+++ b/neo/Core/Console/Commands/DebugRouterCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Neo\Core\Console\Commands;
+
+use Neo\Core\Console\Attribute\Command;
+use Neo\Core\Console\Helper\Args;
+use Neo\Core\Console\Helper\Output;
+use Neo\Core\Console\Interface\CommandInterface;
+use Neo\Core\DI\Container;
+use Neo\Core\Routing\Router;
+
+#[Command(
+    name: 'debug:router',
+    description: 'Display all registered routes for a project'
+)]
+class DebugRouterCommand implements CommandInterface
+{
+
+    public function __construct(
+        private Container $container
+    ){}
+
+    public function execute(array $args): void
+    {
+        $project = Args::option($args, '--project');
+        $filterMethod = Args::option($args, '--method');
+        $filterName = Args::option($args, '--name');
+        $filterPath = Args::option($args, '--path');
+
+        if (!$project) {
+            Output::error('Missing required option: --project=<name>');
+            return;
+        }
+
+        $srcPath = ROOT_DIR . "/src/$project";
+
+        if (!is_dir($srcPath)) {
+            Output::error("Project '$project' not found in src/.");
+            return;
+        }
+
+        $this->container->set('controllerNamespace', "Neo\\Src\\$project\\App\\Controllers");
+        $this->container->set('controllersPath', $srcPath . '/App/Controllers');
+        $this->container->set('storagePath', $srcPath . '/storage');
+
+        try {
+            $router = $this->container->get(Router::class);
+        } catch (\Throwable $e) {
+            Output::error('Unable to load Router: ' . $e->getMessage());
+            return;
+        }
+
+
+        $routes = $router->getRoutes()->all();
+
+        $rows = [];
+        foreach ($routes as $method => $methodRoutes) {
+            foreach ($methodRoutes as $path => $info) {
+                if ($filterMethod && strtoupper($filterMethod) !== strtoupper($method)) {
+                    continue;
+                }
+                if ($filterName && !str_contains($info['name'], $filterName)) {
+                    continue;
+                }
+                if ($filterPath && !str_contains($path, $filterPath)) {
+                    continue;
+                }
+
+                $rows[] = [
+                    'method' => $method,
+                    'path' => $path,
+                    'name' => $info['name'],
+                    'controller' => $info['controller'],
+                    'action' => $info['action'],
+                ];
+            }
+        }
+
+        if (empty($rows)) {
+            Output::warning('No routes found.');
+            return;
+        }
+
+        usort($rows, fn($a, $b) => strcmp($a['path'], $b['path']));
+
+        Output::title(sprintf('Routes (%d)', count($rows)));
+
+        $methodColors = [
+            'GET' => 'green',
+            'POST' => 'yellow',
+            'PUT' => 'cyan',
+            'PATCH' => 'cyan',
+            'DELETE' => 'red',
+        ];
+
+        foreach ($rows as $row) {
+            $color = $methodColors[$row['method']] ?? 'white';
+            $method = Output::colorize(str_pad($row['method'], 7), $color);
+            $path = Output::colorize(str_pad($row['path'], 40), 'white');
+            $name = Output::colorize(str_pad($row['name'], 35), 'dim');
+            $ctrl = Output::colorize($row['controller'] . '::' . $row['action'], 'dim');
+
+            echo "  {$method} {$path} {$name} {$ctrl}\n";
+        }
+
+        Output::newLine();
+    }
+
+    public function getName(): string
+    {
+        return 'debug:router';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Display all registered routes for a project';
+    }
+
+    public function getHelp(): string
+    {
+        Output::usage('debug:router', $this->getDescription());
+        Output::option('--project=<name>',  'Target project inside ./src/');
+        Output::option('--method=<method>', 'Filter by HTTP method (GET, POST...)');
+        Output::option('--name=<name>',     'Filter by route name (partial match)');
+        Output::option('--path=<path>',     'Filter by path (partial match)');
+        Output::newLine();
+        echo "  Examples:\n";
+        Output::example('php bin/neo debug:router --project=MyApp');
+        Output::example('php bin/neo debug:router --project=MyApp --method=GET');
+        Output::example('php bin/neo debug:router --project=MyApp --name=user');
+
+        return '';
+    }
+}


### PR DESCRIPTION
fix(console): bootstrap full App for project-aware commands

- Validate --project existence before App boot to avoid cryptic config errors
- Instantiate App (full module bootstrap) when --project is provided so
  Router, Config, View and all module bindings are available in the container
- Fall back to a lightweight container when no project is specified

feat(console): add debug:router command

Display all registered routes for a given project with optional filters.
Supports --method, --name and --path for narrowing results.