### PR TITLE
fix: strip dot-segments from URL path in sanitizePath()

### DIFF
--- a/neo/Core/Http/Request.php
+++ b/neo/Core/Http/Request.php
@@ -147,6 +147,9 @@ class Request
 
     private function sanitizePath(string $path): string
     {
+        $path = preg_replace('#/\.\.(/|$)#', '/', $path);
+        $path = preg_replace('#/\.(/|$)#', '/', $path);
+
         $path = '/' . trim($path, '/');
         return $path === '/' ? '/' : rtrim($path, '/');
     }


### PR DESCRIPTION
Removes /../ and /./ sequences before normalization to prevent router bypass via path traversal patterns (e.g. /admin/../api/users). realpath() is intentionally avoided — this is URL path handling, not filesystem resolution.