### PR TITLE
fix: quote SQL identifiers with backticks in QueryBuilder

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,8 +114,8 @@ neo/Core/
 - [x] 🟢 **Échapper les messages d'exception** avec `htmlspecialchars()` dans `ErrorHandler.php` l.176-191 `branch: fix/xss-escape-exception-messages`
 - [x] 🟢 **Ajouter une limite de taille** sur `php://input` dans `Request.php` l.65 (ex : 8 Mo) `branch: fix/request-input-size-limit`
 - [x] 🟢 **Valider les IPs** `X-Forwarded-For` avec `filter_var()` dans `Request.php` l.281-298 `branch: fix/validate-x-forwarded-for-ip`
-- [ ] 🟢 **Fix path traversal** — ajouter `realpath()` + vérification de préfixe dans `Request::sanitizePath()` `branch: fix/path-traversal-sanitize-path`
-- [ ] 🟡 **Quoter les identifiants SQL** avec des backticks dans `QueryBuilder.php` l.56, 77, 101-112 `branch: fix/sql-quote-identifiers-backticks`
+- [x] 🟢 **Fix path traversal** — ajouter `realpath()` + vérification de préfixe dans `Request::sanitizePath()` `branch: fix/path-traversal-sanitize-path`
+- [x] 🟡 **Quoter les identifiants SQL** avec des backticks dans `QueryBuilder.php` l.56, 77, 101-112 `branch: fix/sql-quote-identifiers-backticks`
 - [ ] 🟡 **Supprimer l'interpolation SQL directe** dans `AbstractModel.php` l.314-360 → utiliser des identifiants quotés `branch: fix/sql-remove-direct-interpolation`
 - [ ] 🟡 **Remplacer `unserialize()`** par `json_decode()` pour le cache de routes dans `Router.php` l.56 `branch: fix/router-replace-unserialize-cache`
 - [ ] 🟡 **Sécuriser l'inclusion dynamique** `require_once $filePath` dans `Router.php` l.87 — valider la whitelist `branch: fix/router-dynamic-include-whitelist`

--- a/neo/Core/Database/Builder/QueryBuilder.php
+++ b/neo/Core/Database/Builder/QueryBuilder.php
@@ -68,7 +68,7 @@ class QueryBuilder
                 code: 500
             );
         }
-        return $name;
+        return '`' . $name . '`';
     }
 
     /**
@@ -80,19 +80,23 @@ class QueryBuilder
             return $column;
         }
 
-        if (preg_match('/^[a-zA-Z0-9_]+\.\*$/', $column)) {
-            return $column;
+        if (preg_match('/^([a-zA-Z0-9_]+)\.\*$/', $column, $m)) {
+            return '`' . $m[1] . '`.*';
         }
 
-        if (!preg_match('/^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$/', $column)) {
-            throw new DatabaseException(
-                title: 'Query Builder Error',
-                message: sprintf("Invalid SQL column: '%s'.", $column),
-                code: 500
-            );
+        if (preg_match('/^([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)$/', $column, $m)) {
+            return '`' . $m[1] . '`.`' . $m[2] . '`';
         }
 
-        return $column;
+        if (preg_match('/^[a-zA-Z0-9_]+$/', $column)) {
+            return '`' . $column . '`';
+        }
+
+        throw new DatabaseException(
+            title: 'Query Builder Error',
+            message: sprintf("Invalid SQL column: '%s'.", $column),
+            code: 500
+        );
     }
 
     /**
@@ -571,21 +575,23 @@ class QueryBuilder
     {
         try {
             $columns = array_keys($data);
-            $placeholders = array_map(fn($c) => ":$c", $columns);
+            $quotedColumns = array_map(fn($c) => '`' . $this->sanitizeIdentifier($c) . '`', $columns);
+            $placeholders = array_map(fn($c) => ':' . preg_replace('/[^a-zA-Z0-9_]/', '_', $c), $columns);
 
             $sql = sprintf(
                 'INSERT INTO %s (%s) VALUES (%s)',
                 $this->table,
-                implode(',', $columns),
-                implode(',', $placeholders)
+                implode(', ', $quotedColumns),
+                implode(', ', $placeholders)
             );
 
             $stmt = $this->pdo->prepare($sql);
 
             foreach ($data as $key => $value) {
+                $paramKey = ':' . preg_replace('/[^a-zA-Z0-9_]/', '_', $key);
                 $value === null
-                    ? $stmt->bindValue(":$key", null, PDO::PARAM_NULL)
-                    : $stmt->bindValue(":$key", $value);
+                    ? $stmt->bindValue($paramKey, null, PDO::PARAM_NULL)
+                    : $stmt->bindValue($paramKey, $value);
             }
 
             return $this->executeTracked($stmt, [], $sql);
@@ -629,8 +635,9 @@ class QueryBuilder
             $setParams = [];
 
             foreach ($data as $key => $value) {
-                $paramKey = 'set_' . $key;
-                $setParts[] = "$key = :$paramKey";
+                $quotedCol = '`' . $this->sanitizeIdentifier($key) . '`';
+                $paramKey = 'set_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $key);
+                $setParts[] = "$quotedCol = :$paramKey";
                 $setParams[$paramKey] = $value;
             }
 


### PR DESCRIPTION
Wraps table names and column identifiers in backticks via sanitizeIdentifier() and sanitizeColumn() to prevent conflicts with reserved SQL keywords (e.g. `order`, `key`, `group`). Also applies sanitization to raw keys in insert() and update() which previously bypassed identifier validation entirely.