### PR TITLE
fix: whitelist dynamic require_once to controllersPath in Router

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,8 +117,8 @@ neo/Core/
 - [x] 🟢 **Fix path traversal** — ajouter `realpath()` + vérification de préfixe dans `Request::sanitizePath()` `branch: fix/path-traversal-sanitize-path`
 - [x] 🟡 **Quoter les identifiants SQL** avec des backticks dans `QueryBuilder.php` l.56, 77, 101-112 `branch: fix/sql-quote-identifiers-backticks`
 - [x] 🟡 **Supprimer l'interpolation SQL directe** dans `AbstractModel.php` l.314-360 → utiliser des identifiants quotés `branch: fix/sql-remove-direct-interpolation`
-- [ ] 🟡 **Remplacer `unserialize()`** par `json_decode()` pour le cache de routes dans `Router.php` l.56 `branch: fix/router-replace-unserialize-cache`
-- [ ] 🟡 **Sécuriser l'inclusion dynamique** `require_once $filePath` dans `Router.php` l.87 — valider la whitelist `branch: fix/router-dynamic-include-whitelist`
+- [x] 🟡 **Remplacer `unserialize()`** par `json_decode()` pour le cache de routes dans `Router.php` l.56 `branch: fix/router-replace-unserialize-cache`
+- [x] 🟡 **Sécuriser l'inclusion dynamique** `require_once $filePath` dans `Router.php` l.87 — valider la whitelist `branch: fix/router-dynamic-include-whitelist`
 - [ ] 🟡 **Ajouter CSRF** sur les formulaires d'authentification dans `AuthManager.php` `branch: feature/auth-csrf-protection`
 - [ ] 🟠 **Ajouter un timeout de session** dans `SessionGuard` `branch: feature/session-timeout`
 - [ ] 🟠 **Sécuriser les uploads** — validation MIME, limite de taille, assainissement du nom de fichier `branch: feature/secure-file-uploads`

--- a/neo/Core/Routing/Router.php
+++ b/neo/Core/Routing/Router.php
@@ -50,7 +50,7 @@ class Router
      */
     private function scanControllers(): void
     {
-        $cacheFile = $this->container->get('storagePath') . '/var/cache/router/routes.php';
+        $cacheFile = $this->container->get('storagePath') . '/var/cache/router/routes.json';
 
         if (!$this->isDebug() && file_exists($cacheFile)) {
             $json = file_get_contents($cacheFile);
@@ -60,6 +60,8 @@ class Router
                 return;
             }
         }
+
+        $realControllersPath = realpath($this->controllersPath);
 
         $rii = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($this->controllersPath)
@@ -72,6 +74,14 @@ class Router
 
             $filePath = $file->getRealPath();
             if ($filePath === false) continue;
+
+            if ($realControllersPath === false || !str_starts_with($filePath, $realControllersPath . DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            if (pathinfo($filePath, PATHINFO_EXTENSION) !== 'php') {
+                continue;
+            }
 
             $src = file_get_contents($filePath);
             if ($src === false) continue;


### PR DESCRIPTION
Adds realpath() prefix check before require_once $filePath to ensure included files are strictly contained within the configured controllers directory, preventing symlink-based or traversal-based inclusion of files outside the expected scope.