### PR TITLE
feature: add session timeout to SessionGuard

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,7 +120,7 @@ neo/Core/
 - [x] 🟡 **Remplacer `unserialize()`** par `json_decode()` pour le cache de routes dans `Router.php` l.56 `branch: fix/router-replace-unserialize-cache`
 - [x] 🟡 **Sécuriser l'inclusion dynamique** `require_once $filePath` dans `Router.php` l.87 — valider la whitelist `branch: fix/router-dynamic-include-whitelist`
 - [ ] 🟡 **Ajouter CSRF** sur les formulaires d'authentification dans `AuthManager.php` `branch: feature/auth-csrf-protection`
-- [ ] 🟠 **Ajouter un timeout de session** dans `SessionGuard` `branch: feature/session-timeout`
+- [x] 🟠 **Ajouter un timeout de session** dans `SessionGuard` `branch: feature/session-timeout`
 - [ ] 🟠 **Sécuriser les uploads** — validation MIME, limite de taille, assainissement du nom de fichier `branch: feature/secure-file-uploads`
 - [ ] 🟠 **Rate limiting** sur les tentatives de connexion (Middleware dédié ou dans `AuthManager`) `branch: feature/auth-rate-limiting`
 

--- a/neo/Core/Application/Commands/ProjectCreateCommand.php
+++ b/neo/Core/Application/Commands/ProjectCreateCommand.php
@@ -301,6 +301,7 @@ return [
             'home'       => '',
             'secret'     => '',
             'expiration' => 3600,
+            'timeout'    => 1800,
             'algorithm'  => 'HS256',
         ],
     ],

--- a/neo/Core/Security/Auth/AuthManager.php
+++ b/neo/Core/Security/Auth/AuthManager.php
@@ -146,7 +146,8 @@ class AuthManager
                 $this->config['model'],
                 $this->config['identifier'] ?? 'email',
                 $this->config['password'] ?? 'password',
-                $role
+                $role,
+                (int) ($options['timeout'] ?? 1800)
             ),
         };
     }

--- a/neo/Core/Security/Auth/Guard/SessionGuard.php
+++ b/neo/Core/Security/Auth/Guard/SessionGuard.php
@@ -13,6 +13,8 @@ use Neo\Core\Security\Auth\PasswordManager;
 final class SessionGuard implements GuardInterface
 {
     private const string SESSION_KEY = '_auth_user_id';
+    private const string SESSION_LAST_ACTIVITY_KEY = '_auth_last_activity';
+    private const int DEFAULT_TIMEOUT = 1800;
 
     /**
      * @param array<string, mixed> $role
@@ -23,7 +25,8 @@ final class SessionGuard implements GuardInterface
         private readonly string $model,
         private readonly string $identifier,
         private readonly string $password,
-        private readonly array $role = []
+        private readonly array $role = [],
+        private readonly int $timeout = self::DEFAULT_TIMEOUT,
     ) {}
 
     /**
@@ -70,16 +73,30 @@ final class SessionGuard implements GuardInterface
         $pk = $user::getPrimaryKey();
         $this->session->regenerate();
         $this->session->set(self::SESSION_KEY, $user->{$pk});
+        $this->session->set(self::SESSION_LAST_ACTIVITY_KEY, time());
     }
 
     public function logout(): void
     {
         $this->session->remove(self::SESSION_KEY);
+        $this->session->remove(self::SESSION_LAST_ACTIVITY_KEY);
     }
 
     public function check(): bool
     {
-        return $this->session->has(self::SESSION_KEY);
+        if (!$this->session->has(self::SESSION_KEY)) {
+            return false;
+        }
+
+        $lastActivity = $this->session->get(self::SESSION_LAST_ACTIVITY_KEY, 0);
+
+        if ((time() - $lastActivity) > $this->timeout) {
+            $this->logout();
+            return false;
+        }
+
+        $this->session->set(self::SESSION_LAST_ACTIVITY_KEY, time());
+        return true;
     }
 
     public function user(): ?AbstractModel


### PR DESCRIPTION
Tracks last activity timestamp in session on login and check(). Automatically logs out inactive users after configurable timeout (default 30min). Timeout is injectable via auth.options.timeout in app.config.php.