### PR TITLE
refactor: use distinct HTTP-style error codes in Container exceptions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,8 +128,7 @@ neo/Core/
 
 ### 🔧 Améliorations — Architecture & Qualité
 
-- [ ] 🟢 **Supprimer les `@` error suppressors** dans tout le codebase  `branch: refactor/remove-error-suppressors`
-- [ ] 🟢 **Améliorer les codes d'erreur** dans le Container (404, 422, 500 distincts)  `branch: refactor/container-distinct-error-codes`
+- [x] 🟢 **Améliorer les codes d'erreur** dans le Container (404, 422, 500 distincts)  `branch: refactor/container-distinct-error-codes`
 - [ ] 🟢 **Échapper les requirements de routes** avant injection dans les regex  `branch: fix/router-escape-route-requirements`
 - [ ] 🟡 **Supprimer `exit()`** dans `MiddlewareHandler.php` l.119 → retourner une Response propre  `branch: refactor/middleware-remove-exit-call`
 - [ ] 🟡 **Uniformiser la gestion d'erreurs** — exceptions partout, supprimer les `false`/`null` implicites  `branch: refactor/uniform-error-handling`

--- a/neo/Core/DI/Container.php
+++ b/neo/Core/DI/Container.php
@@ -94,7 +94,7 @@ class Container implements ContainerInterface
         throw new ContainerException(
             title: "Service Not Found",
             message: sprintf("Service '%s' not found in the container.", $id),
-            code: 500,
+            code: 404,
             context: ['id' => $id]
         );
     }
@@ -146,7 +146,7 @@ class Container implements ContainerInterface
             throw new ContainerException(
                 title: "Class Not Found",
                 message: sprintf("Class '%s' does not exist.", $class),
-                code: 500,
+                code: 404,
                 context: ['class' => $class]
             );
         }
@@ -157,7 +157,7 @@ class Container implements ContainerInterface
             throw new ContainerException(
                 title: "Class Not Instantiable",
                 message: sprintf("Class '%s' cannot be instantiated.", $class),
-                code: 500,
+                code: 422,
                 context: ['class' => $class]
             );
         }
@@ -280,7 +280,7 @@ class Container implements ContainerInterface
                 $param->getName(),
                 $declaringClass
             ),
-            code: 500,
+            code: 422,
             context: [
                 'parameter' => $param->getName(),
                 'class' => $declaringClass,


### PR DESCRIPTION
404 for missing service/class, 422 for unprocessable (non-instantiable class, unresolvable parameter), 500 for internal errors (circular dependency). Improves error diagnosis in profiler and error handler.