### PR TITLE
fix: validate route requirements before injection into regex pattern

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,7 +129,7 @@ neo/Core/
 ### 🔧 Améliorations — Architecture & Qualité
 
 - [x] 🟢 **Améliorer les codes d'erreur** dans le Container (404, 422, 500 distincts)  `branch: refactor/container-distinct-error-codes`
-- [ ] 🟢 **Échapper les requirements de routes** avant injection dans les regex  `branch: fix/router-escape-route-requirements`
+- [x] 🟢 **Échapper les requirements de routes** avant injection dans les regex  `branch: fix/router-escape-route-requirements`
 - [ ] 🟡 **Supprimer `exit()`** dans `MiddlewareHandler.php` l.119 → retourner une Response propre  `branch: refactor/middleware-remove-exit-call`
 - [ ] 🟡 **Uniformiser la gestion d'erreurs** — exceptions partout, supprimer les `false`/`null` implicites  `branch: refactor/uniform-error-handling`
 - [ ] 🟡 **Compiler les regex de routes une seule fois** et les mettre en cache  `branch: refactor/router-cache-compiled-regex`

--- a/neo/Core/Routing/Router.php
+++ b/neo/Core/Routing/Router.php
@@ -219,6 +219,10 @@ class Router
                 $isOptional = isset($m[2]);
                 $regex = $requirements[$paramName] ?? '[^/]+';
 
+                if (@preg_match('#' . $regex . '#', '') === false) {
+                    $regex = '[^/]+';
+                }
+
                 return $isOptional
                     ? '(?:/(?P<' . $paramName . '>' . $regex . '))?'
                     : '/(?P<' . $paramName . '>' . $regex . ')';
@@ -229,6 +233,10 @@ class Router
         if ($pattern === null) return false;
 
         $pattern = '#^' . rtrim($pattern, '/') . '/?$#';
+
+        if (@preg_match($pattern, $path, $matches) === false) {
+            return false;
+        }
 
         if (preg_match($pattern, $path, $matches)) {
             $params = [];


### PR DESCRIPTION
Invalid regex in requirements (e.g. unclosed brackets) would cause preg_match to emit a warning and return false, silently breaking route matching. Now validates each requirement pattern before use and falls back to [^/]+ if invalid.