### PR TITLE
refactor: replace implicit false/null with exceptions in Mailer and M…

### DIFF
--- a/neo/Core/Database/Migration/MigrationSchemaSnapshot.php
+++ b/neo/Core/Database/Migration/MigrationSchemaSnapshot.php
@@ -80,7 +80,11 @@ final class MigrationSchemaSnapshot
         $last = $this->getLastHash();
 
         if ($last === null) {
-            return false;
+            throw new DatabaseException(
+                title: 'Migration Snapshot Error',
+                message: 'No schema snapshot found. Run a snapshot first.',
+                code: 404
+            );
         }
 
         return $last !== $this->getCurrentHash();

--- a/neo/Core/Utils/Mailer/Exception/MailerException.php
+++ b/neo/Core/Utils/Mailer/Exception/MailerException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Neo\Core\Utils\Mailer\Exception;
+
+use Neo\Core\Error\Exception\FrameworkException;
+
+class MailerException extends FrameworkException
+{}

--- a/neo/Core/Utils/Mailer/Mailer.php
+++ b/neo/Core/Utils/Mailer/Mailer.php
@@ -7,6 +7,7 @@ use Neo\Core\DI\Container;
 use Neo\Core\DI\Exception\ContainerException;
 use Neo\Core\Utils\Config\Config;
 use Neo\Core\Utils\Logger\Logger;
+use Neo\Core\Utils\Mailer\Exception\MailerException;
 use Neo\Core\View\View;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -182,7 +183,13 @@ class Mailer
             ], 'Mailer');
 
             $this->reset();
-            return false;
+
+            throw new MailerException(
+                title: 'Mailer Send Error',
+                message: sprintf("Failed to send email to '%s': %s", $this->to, $e->getMessage()),
+                code: 500,
+                previous: $e
+            );
         }
     }
 


### PR DESCRIPTION
…igrationSchemaSnapshot

Mailer::send() now throws MailerException on SMTP failure instead of returning false silently — callers can distinguish disabled mailer (false) from send error (exception). MigrationSchemaSnapshot::hasChanged() throws DatabaseException when no snapshot exists, removing the ambiguity between "no snapshot" and "no change".