### PR TITLE
feature: add explicit priority ordering to Middleware attribute

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,8 +135,8 @@ neo/Core/
 - [x] 🟡 **Compiler les regex de routes une seule fois** et les mettre en cache  `branch: refactor/router-cache-compiled-regex`
 - [ ] 🟡 **Améliorer le typage** dans les zones utilisant `mixed` ou des tableaux non typés  `branch: refactor/improve-mixed-type-hints`
 - [x] 🟠 **Remplacer le singleton statique du Container** par une injection via le kernel  `branch: refactor/container-remove-static-singleton`
-- [ ] 🟠 **Invalider l'identity map** (`AbstractModel::$instanceCache`) après les mutations en CLI  `branch: fix/model-invalidate-identity-map-cli`
-- [ ] 🟠 **Ajouter un système d'ordre explicite** pour l'exécution des middlewares  `branch: feature/middleware-explicit-order`
+- [x] 🟠 **Invalider l'identity map** (`AbstractModel::$instanceCache`) après les mutations en CLI  `branch: fix/model-invalidate-identity-map-cli`
+- [x] 🟠 **Ajouter un système d'ordre explicite** pour l'exécution des middlewares  `branch: feature/middleware-explicit-order`
 - [ ] 🔴 **Séparer `AbstractModel`** en `Model` + `QueryScope` + `Relationships` (trop de responsabilités)  `branch: breaking/split-abstract-model`
 
 ---

--- a/neo/Core/Security/Middleware/Attribute/Middleware.php
+++ b/neo/Core/Security/Middleware/Attribute/Middleware.php
@@ -19,6 +19,8 @@ class Middleware
     /** @var array<string, mixed> */
     public array $params;
 
+    public int $priority;
+
     /**
      * @param array<string, mixed> $params
      */
@@ -27,12 +29,14 @@ class Middleware
         string $message = '',
         string $onError = 'block',
         ?string $redirect = null,
-        array $params = []
+        array $params = [],
+        int $priority = 0
     ) {
         $this->use = $use;
         $this->message = $message;
         $this->onError = $onError;
         $this->redirect = $redirect;
         $this->params = $params;
+        $this->priority = $priority;
     }
 }

--- a/neo/Core/Security/Middleware/MiddlewareHandler.php
+++ b/neo/Core/Security/Middleware/MiddlewareHandler.php
@@ -168,6 +168,7 @@ class MiddlewareHandler
                 'redirect' => $i->redirect,
                 'isClass' => true,
                 'params' => $i->params,
+                'priority' => $i->priority,
             ];
         }
 
@@ -188,6 +189,7 @@ class MiddlewareHandler
                     'redirect' => $i->redirect,
                     'isClass' => false,
                     'params' => $i->params,
+                    'priority' => $i->priority,
                 ];
             }
 
@@ -196,6 +198,8 @@ class MiddlewareHandler
                 $all[] = $this->buildRateLimitMeta($i, false);
             }
         }
+
+        usort($all, fn($a, $b) => $b['priority'] <=> $a['priority']);
 
         return $all;
     }
@@ -223,6 +227,7 @@ class MiddlewareHandler
                 'decaySeconds' => $attr->decaySeconds,
                 'message' => $attr->message,
             ],
+            'priority' => 0,
         ];
     }
 


### PR DESCRIPTION
Adds a priority parameter (default 0) to the Middleware attribute. MiddlewareHandler::getMiddlewares() sorts collected middlewares by priority descending before execution. Higher priority runs first. RateLimit middlewares default to priority 0. Fully backward compatible — existing middleware declarations without priority are unaffected.