### PR TITLE
fix: fix Fs::pascalCase joining parts with underscore instead of conc…

### DIFF
--- a/neo/Core/Console/Helper/Fs.php
+++ b/neo/Core/Console/Helper/Fs.php
@@ -68,7 +68,7 @@ final class Fs
                     : mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1),
                 $parts
             );
-            $result .= implode('_', $parts);
+            $result .= implode('', $parts);
         }
 
         return $result;


### PR DESCRIPTION
…atenating

implode('_', $parts) was used after parts were already capitalized individually, producing "My_Command_Name" instead of "MyCommandName". Changed to implode('', $parts) to properly concatenate into PascalCase.