### PR TITLE
feat: generate default {Name}Module.php on project creation

### DIFF
--- a/neo/App.php
+++ b/neo/App.php
@@ -51,7 +51,8 @@ class App
         new ApplicationPaths($this->container)->register();
 
         $moduleManager = new ModuleManager($this->container)
-            ->discover(__DIR__ . '/Core');
+            ->discover(__DIR__ . '/Core')
+            ->discover($this->container->get('appPath'));
 
         if (php_sapi_name() !== 'cli') {
             $moduleManager->boot();

--- a/neo/Core/Application/ApplicationPaths.php
+++ b/neo/Core/Application/ApplicationPaths.php
@@ -22,6 +22,7 @@ readonly class ApplicationPaths
         $basePath = realpath(__DIR__ . '/../../../');
 
         $this->container->set('basePath', $basePath);
+        $this->container->set('appPath', $basePath . '/src/' . $appName);
 
         $publicPath = $this->resolvePublicPath($basePath);
 

--- a/neo/Core/Application/Commands/ProjectCreateCommand.php
+++ b/neo/Core/Application/Commands/ProjectCreateCommand.php
@@ -142,6 +142,7 @@ final class ProjectCreateCommand extends AbstractCommand
             Fs::ensureDir($path . '/' . $directory);
         }
 
+        $this->generateDefaultModule($path, $name);
         $this->generateDefaultController($path . '/App/Controllers/', $name, $originalName);
         $this->generateDefaultLayoutView($path . '/App/Views/layouts/', $name);
         $this->generateDefaultView($path . '/App/Views/pages/default/', $name);
@@ -505,5 +506,38 @@ PHP;
         }
 
         return ['localhost', $port];
+    }
+
+    private function generateDefaultModule(string $path, string $name): void
+    {
+        $content = <<<PHP
+<?php
+declare(strict_types=1);
+
+namespace Neo\Src\\$name;
+
+use Neo\Core\DI\Container;
+use Neo\Core\Module\Abstract\AbstractModule;
+use Neo\Core\Utils\Config\ConfigModule;
+use Neo\Core\View\ViewModule;
+use Neo\Core\Utils\Cache\CacheModule;
+
+final class {$name}Module extends AbstractModule
+{
+    public function dependencies(): array
+    {
+        return [
+            // ClassModule::class,
+        ];
+    }
+
+    public function register(Container \$container): void
+    {
+        // Registration of project-specific services ($name)
+    }
+}
+PHP;
+
+        file_put_contents($path . "/{$name}Module.php", $content);
     }
 }


### PR DESCRIPTION
- Add generateDefaultModule() to ProjectCreateCommand, creating a {Name}Module.php at the project root (extends AbstractModule)
- Register appPath in ApplicationPaths (src/{appName})
- Make ModuleManager discover appPath in addition to Core, so each generated project's module (and any future ones) is auto-loaded scoped to the currently detected application