### PR TITLE
fix: support explicit domain in @translatable annotation

### DIFF
--- a/neo/Core/Translation/Commands/TranslationSyncCommand.php
+++ b/neo/Core/Translation/Commands/TranslationSyncCommand.php
@@ -219,13 +219,16 @@ final class TranslationSyncCommand extends AbstractCommand
             }
 
             preg_match_all(
-                '/=>\s*([\'"])((?:\\\\.|(?!\1).)*)\1\s*,?\s*\/\/\s*@translatable/u',
+                '/=>\s*([\'"])((?:\\\\.|(?!\1).)*)\1\s*,?\s*\/\/\s*@translatable(?::(\w+))?/u',
                 $content,
-                $configMatches
+                $configMatches,
+                PREG_SET_ORDER
             );
 
-            foreach ($configMatches[2] as $key) {
-                $keysByDomain[TranslationDomain::DEFAULT][] = $this->unescapeString($key);
+            foreach ($configMatches as $match) {
+                $key = $this->unescapeString($match[2]);
+                $domain = $match[3] ?? TranslationDomain::DEFAULT;
+                $keysByDomain[$domain][] = $key;
             }
         }
 


### PR DESCRIPTION
- Extend @translatable annotation to accept an optional domain suffix (@translatable:domain), falling back to TranslationDomain::DEFAULT when omitted
- Remove duplicated/dead regex block that re-processed the same matches and forced everything into the default domain
- Fixes dynamic keys (e.g. day_of_week values, footer description) being dropped from their intended domain on every sync