### PR TITLE
fix: remove single-project fallback in ApplicationDetector

### DIFF
--- a/neo/Core/Application/ApplicationDetector.php
+++ b/neo/Core/Application/ApplicationDetector.php
@@ -94,12 +94,6 @@ class ApplicationDetector
             }
         }
 
-        $projects = glob(__DIR__ . '/../../../src/*', GLOB_ONLYDIR);
-        if (count($projects) === 1) {
-            $this->container->set('application', basename($projects[0]));
-            return;
-        }
-
         throw new ApplicationException(
             title: 'Application Error',
             message: sprintf("No application detected for access: '%s'.", $server),


### PR DESCRIPTION
- Remove the automatic fallback that loaded the only project found in src/ when no exact 'access' match was found for the current host
- This fallback caused any subdomain (e.g. dev-*.neophp.fr) to load the sole existing project regardless of its configured 'access', bypassing the intended host-based routing and creating a security risk once multiple environments/projects coexist
- Now throws ApplicationException("No application detected...") as expected when no project's 'access' matches the incoming host