### PR TITLE
feat: generate incremental ALTER TABLE migrations via schema diff

### DIFF
--- a/neo/Core/Database/Commands/DatabaseMigrationGenerateCommand.php
+++ b/neo/Core/Database/Commands/DatabaseMigrationGenerateCommand.php
@@ -11,7 +11,10 @@ use Neo\Core\Console\Input\InputOption;
 use Neo\Core\Console\Output\Output;
 use Neo\Core\Database\DatabaseConnection;
 use Neo\Core\Database\DatabaseIntrospector;
+use Neo\Core\Database\DatabaseManager;
 use Neo\Core\Database\Migration\MigrationGenerator;
+use Neo\Core\Database\Migration\MigrationSchemaSnapshot;
+use Neo\Core\Database\Migration\SchemaDiffer;
 use Neo\Core\DI\Container;
 
 #[Command(
@@ -45,7 +48,7 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
     public function do(Input $input, Output $output): ExitCode
     {
         $project = $input->getOption('project') ?? Input::choice('Target project ?', $this->getAvailableProjects());
-        $name = $input->getOption('name') ?? Input::ask('Migration name ?', 'initial_schema');
+        $name = $input->getOption('name') ?? Input::ask('Migration name ?', 'schema_update');
 
         $basePath = ROOT_DIR . "/src/$project";
         $migrationsPath = "$basePath/Database/Migrations";
@@ -72,9 +75,35 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
                 return ExitCode::SUCCESS;
             }
 
-            Output::info(count($tables) . ' table(s) found.');
+            $db = $this->container->get(DatabaseManager::class);
+            $snapshot = new MigrationSchemaSnapshot($db, $introspector);
             $generator = new MigrationGenerator($introspector);
-            $file = $generator->generate($migrationsPath, $name);
+
+            $previousSchema = $snapshot->getLastSchema();
+
+            if ($previousSchema === null) {
+                Output::info('No previous snapshot found. Generating full schema migration.');
+                $file = $generator->generate($migrationsPath, $name);
+                $snapshot->take();
+
+                Output::success('Migration file generated:');
+                Output::muted('  ' . str_replace(ROOT_DIR, '', $file));
+                return ExitCode::SUCCESS;
+            }
+
+            $currentSchema = $snapshot->getCurrentSchema();
+            $differ = new SchemaDiffer();
+            $diff = $differ->diff($previousSchema, $currentSchema);
+
+            if ($differ->isEmpty($diff)) {
+                Output::info('No schema changes detected. Nothing to migrate.');
+                return ExitCode::SUCCESS;
+            }
+
+            $this->printDiffSummary($diff);
+
+            $file = $generator->generateDiff($migrationsPath, $name, $diff);
+            $snapshot->take();
 
             Output::success('Migration file generated:');
             Output::muted('  ' . str_replace(ROOT_DIR, '', $file));
@@ -83,6 +112,36 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
         } catch (\Throwable $e) {
             Output::error('Generation failed: ' . $e->getMessage());
             return ExitCode::FAILURE;
+        }
+    }
+
+    /**
+     * @param array{
+     *     tablesToCreate: array<string, mixed>,
+     *     tablesToDrop: array<string, mixed>,
+     *     tableChanges: array<string, array{added: array<int, array<string,mixed>>, removed: array<int, array<string,mixed>>, modified: array<int, array{before: array<string,mixed>, after: array<string,mixed>}>}>
+     * } $diff
+     */
+    private function printDiffSummary(array $diff): void
+    {
+        foreach (array_keys($diff['tablesToCreate']) as $table) {
+            Output::success("  + table `$table`");
+        }
+
+        foreach (array_keys($diff['tablesToDrop']) as $table) {
+            Output::warning("  - table `$table`");
+        }
+
+        foreach ($diff['tableChanges'] as $table => $changes) {
+            foreach ($changes['added'] as $col) {
+                Output::success("  + {$table}.{$col['name']}");
+            }
+            foreach ($changes['removed'] as $col) {
+                Output::warning("  - {$table}.{$col['name']}");
+            }
+            foreach ($changes['modified'] as $change) {
+                Output::info("  ~ {$table}.{$change['after']['name']}");
+            }
         }
     }
 
@@ -96,12 +155,12 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
         $this->container->set('controllersPath', "$srcPath/App/Controllers");
         $this->container->set('storagePath', "$srcPath/Storage");
         $this->container->set('configsPath', "$srcPath/Config");
-        $this->container->set('repositoryPath', "$srcPath/Repository");
-        $this->container->set('modelPath', "$srcPath/Model");
-        $this->container->set('formPath', "$srcPath/App/Forms");
-        $this->container->set('modelNamespace', "Neo\\Src\\$project\\Model");
-        $this->container->set('repositoryNamespace', "Neo\\Src\\$project\\Repository");
-        $this->container->set('formNamespace', "Neo\\Src\\$project\\App\\Forms");
+        $this->container->set('repositoryPath', "$srcPath/Database/Repository");
+        $this->container->set('modelPath', "$srcPath/Database/Model");
+        $this->container->set('formPath', "$srcPath/Database/Forms");
+        $this->container->set('modelNamespace', "Neo\\Src\\$project\\Database\\Model");
+        $this->container->set('repositoryNamespace', "Neo\\Src\\$project\\Database\\Repository");
+        $this->container->set('formNamespace', "Neo\\Src\\$project\\Database\\Forms");
     }
 
     protected function getAvailableProjects(): array

--- a/neo/Core/Database/Migration/MigrationGenerator.php
+++ b/neo/Core/Database/Migration/MigrationGenerator.php
@@ -17,6 +17,94 @@ final class MigrationGenerator
      */
     public function generate(string $migrationsPath, string $name): string
     {
+        $tables = $this->introspector->getTables();
+
+        $upLines = [];
+        $downLines = [];
+
+        foreach ($tables as $table) {
+            if (in_array($table, ['neo_migrations', 'neo_schema_snapshots'], true)) {
+                continue;
+            }
+
+            $columns = $this->introspector->getColumns($table);
+            $upLines[] = $this->executeLine($this->buildCreateTableSql($table, $columns));
+            $downLines[] = $this->executeLine("DROP TABLE IF EXISTS `$table`");
+        }
+
+        return $this->writeFile(
+            $migrationsPath,
+            $name,
+            implode("\n\n", $upLines),
+            implode("\n", array_reverse($downLines))
+        );
+    }
+
+    /**
+     * @param array{
+     *     tablesToCreate: array<string, array<int, array<string, mixed>>>,
+     *     tablesToDrop: array<string, array<int, array<string, mixed>>>,
+     *     tableChanges: array<string, array{
+     *         added: array<int, array<string, mixed>>,
+     *         removed: array<int, array<string, mixed>>,
+     *         modified: array<int, array{before: array<string, mixed>, after: array<string, mixed>}>
+     *     }>
+     * } $diff
+     */
+    public function generateDiff(string $migrationsPath, string $name, array $diff): string
+    {
+        $upLines = [];
+        $downLines = [];
+
+        foreach ($diff['tablesToCreate'] as $table => $columns) {
+            $upLines[] = $this->executeLine($this->buildCreateTableSql($table, $columns));
+            $downLines[] = $this->executeLine("DROP TABLE IF EXISTS `$table`");
+        }
+
+        foreach ($diff['tablesToDrop'] as $table => $columns) {
+            $upLines[] = $this->executeLine("DROP TABLE IF EXISTS `$table`");
+            $downLines[] = $this->executeLine($this->buildCreateTableSql($table, $columns));
+        }
+
+        foreach ($diff['tableChanges'] as $table => $changes) {
+            foreach ($changes['added'] as $col) {
+                $upLines[] = $this->executeLine(
+                    "ALTER TABLE `$table` ADD COLUMN " . $this->buildColumnDefinition($col)
+                );
+                $downLines[] = $this->executeLine(
+                    "ALTER TABLE `$table` DROP COLUMN `{$col['name']}`"
+                );
+            }
+
+            foreach ($changes['removed'] as $col) {
+                $upLines[] = $this->executeLine(
+                    "ALTER TABLE `$table` DROP COLUMN `{$col['name']}`"
+                );
+                $downLines[] = $this->executeLine(
+                    "ALTER TABLE `$table` ADD COLUMN " . $this->buildColumnDefinition($col)
+                );
+            }
+
+            foreach ($changes['modified'] as $change) {
+                $upLines[] = $this->executeLine(
+                    "ALTER TABLE `$table` MODIFY COLUMN " . $this->buildColumnDefinition($change['after'])
+                );
+                $downLines[] = $this->executeLine(
+                    "ALTER TABLE `$table` MODIFY COLUMN " . $this->buildColumnDefinition($change['before'])
+                );
+            }
+        }
+
+        return $this->writeFile(
+            $migrationsPath,
+            $name,
+            implode("\n\n", $upLines),
+            implode("\n", array_reverse($downLines))
+        );
+    }
+
+    private function writeFile(string $migrationsPath, string $name, string $upBody, string $downBody): string
+    {
         if (!is_dir($migrationsPath)) {
             mkdir($migrationsPath, 0777, true);
         }
@@ -24,13 +112,8 @@ final class MigrationGenerator
         $timestamp = date('Ymd_His');
         $className = 'MigrationVersion_' . $timestamp;
         $file = "$migrationsPath/$className.php";
-
-        $tables = $this->introspector->getTables();
-
-        $upBody = $this->buildUpBody($tables);
-        $downBody = $this->buildDownBody($tables);
-
         $date = date('Y-m-d H:i:s');
+
         $content = <<<PHP
 <?php
 declare(strict_types=1);
@@ -59,79 +142,64 @@ PHP;
     }
 
     /**
-     * @param array<int, string> $tables
-     * @throws DatabaseException
+     * @param array<int, array<string, mixed>> $columns
      */
-    private function buildUpBody(array $tables): string
+    private function buildCreateTableSql(string $table, array $columns): string
     {
-        $lines = [];
+        $defs = [];
+        $primary = [];
 
-        foreach ($tables as $table) {
-            if (in_array($table, ['neo_migrations', 'neo_schema_snapshots'], true)) {
-                continue;
+        foreach ($columns as $col) {
+            $defs[] = '        ' . $this->buildColumnDefinition($col);
+
+            if (($col['key'] ?? '') === 'PRI') {
+                $primary[] = "`{$col['name']}`";
             }
-
-            $columns = $this->introspector->getColumns($table);
-            $defs = [];
-            $primary = [];
-
-            foreach ($columns as $col) {
-                $def = "        `{$col['name']}` {$col['type']}";
-
-                if (!$col['nullable']) {
-                    $def .= ' NOT NULL';
-                }
-
-                $isCurrentTimestampDefault = $col['default'] !== null
-                    && strtoupper((string) $col['default']) === 'CURRENT_TIMESTAMP';
-
-                if ($col['default'] !== null) {
-                    $def .= $isCurrentTimestampDefault
-                        ? ' DEFAULT CURRENT_TIMESTAMP'
-                        : " DEFAULT '{$col['default']}'";
-                }
-
-                $extra = trim((string) preg_replace('/DEFAULT_GENERATED/i', '', (string) $col['extra']));
-
-                if ($extra !== '' && strcasecmp($extra, 'auto_increment') !== 0) {
-                    $def .= ' ' . strtoupper($extra);
-                } elseif (strcasecmp($extra, 'auto_increment') === 0) {
-                    $def .= ' AUTO_INCREMENT';
-                }
-
-                $defs[] = $def;
-
-                if ($col['key'] === 'PRI') {
-                    $primary[] = "`{$col['name']}`";
-                }
-            }
-
-            if (!empty($primary)) {
-                $defs[] = '        PRIMARY KEY (' . implode(', ', $primary) . ')';
-            }
-
-            $colsSql = implode(",\n", $defs);
-            $sql = "CREATE TABLE IF NOT EXISTS `$table` (\n$colsSql\n    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
-
-            $escaped = str_replace(["\\", "'"], ["\\\\", "\\'"], $sql);
-            $lines[] = "        \$db->execute('" . $escaped . "');";
         }
 
-        return implode("\n\n", $lines);
+        if (!empty($primary)) {
+            $defs[] = '        PRIMARY KEY (' . implode(', ', $primary) . ')';
+        }
+
+        $colsSql = implode(",\n", $defs);
+
+        return "CREATE TABLE IF NOT EXISTS `$table` (\n$colsSql\n    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
     }
 
     /**
-     * @param array<int, string> $tables
+     * @param array<string, mixed> $col
      */
-    private function buildDownBody(array $tables): string
+    private function buildColumnDefinition(array $col): string
     {
-        $lines = [];
-        $reversed = array_reverse(array_filter($tables, fn($t) => $t !== 'neo_migrations'));
+        $def = "`{$col['name']}` {$col['type']}";
 
-        foreach ($reversed as $table) {
-            $lines[] = "        \$db->execute('DROP TABLE IF EXISTS `$table`');";
+        if (empty($col['nullable'])) {
+            $def .= ' NOT NULL';
         }
 
-        return implode("\n", $lines);
+        $isCurrentTimestampDefault = $col['default'] !== null
+            && strtoupper((string) $col['default']) === 'CURRENT_TIMESTAMP';
+
+        if ($col['default'] !== null) {
+            $def .= $isCurrentTimestampDefault
+                ? ' DEFAULT CURRENT_TIMESTAMP'
+                : " DEFAULT '{$col['default']}'";
+        }
+
+        $extra = trim((string) preg_replace('/DEFAULT_GENERATED/i', '', (string) $col['extra']));
+
+        if (strcasecmp($extra, 'auto_increment') === 0) {
+            $def .= ' AUTO_INCREMENT';
+        } elseif ($extra !== '') {
+            $def .= ' ' . strtoupper($extra);
+        }
+
+        return $def;
+    }
+
+    private function executeLine(string $sql): string
+    {
+        $escaped = str_replace(["\\", "'"], ["\\\\", "\\'"], $sql);
+        return "        \$db->execute('" . $escaped . "');";
     }
 }

--- a/neo/Core/Database/Migration/MigrationSchemaSnapshot.php
+++ b/neo/Core/Database/Migration/MigrationSchemaSnapshot.php
@@ -52,42 +52,54 @@ final class MigrationSchemaSnapshot
     }
 
     /**
+     * @return array<string, array<int, array<string, mixed>>>|null
      * @throws DatabaseException
      */
-    public function getLastHash(): ?string
+    public function getLastSchema(): ?array
     {
         $row = $this->db->fetch(sprintf(
-            'SELECT schema_hash FROM `%s` ORDER BY id DESC LIMIT 1',
+            'SELECT schema_dump FROM `%s` ORDER BY id DESC LIMIT 1',
             self::TABLE
         ));
 
-        return $row['schema_hash'] ?? null;
-    }
-
-    /**
-     * @throws DatabaseException
-     */
-    public function getCurrentHash(): string
-    {
-        return hash('sha256', $this->buildDump());
-    }
-
-    /**
-     * @throws DatabaseException
-     */
-    public function hasChanged(): bool
-    {
-        $last = $this->getLastHash();
-
-        if ($last === null) {
-            throw new DatabaseException(
-                title: 'Migration Snapshot Error',
-                message: 'No schema snapshot found. Run a snapshot first.',
-                code: 404
-            );
+        if ($row === null || !isset($row['schema_dump'])) {
+            return null;
         }
 
-        return $last !== $this->getCurrentHash();
+        $decoded = json_decode($row['schema_dump'], true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @return array<string, array<int, array<string, mixed>>>
+     * @throws DatabaseException
+     */
+    public function getCurrentSchema(): array
+    {
+        return $this->buildDumpArray();
+    }
+
+    /**
+     * @return array<string, array<int, array<string, mixed>>>
+     * @throws DatabaseException
+     */
+    private function buildDumpArray(): array
+    {
+        $tables = $this->introspector->getTables();
+        $dump = [];
+
+        foreach ($tables as $table) {
+            if (in_array($table, ['neo_migrations', self::TABLE], true)) {
+                continue;
+            }
+
+            $dump[$table] = $this->introspector->getColumns($table);
+        }
+
+        ksort($dump);
+
+        return $dump;
     }
 
     /**
@@ -95,20 +107,9 @@ final class MigrationSchemaSnapshot
      */
     private function buildDump(): string
     {
-        $tables = $this->introspector->getTables();
-        $dump = [];
-
-        foreach ($tables as $table) {
-            if (in_array($table, ['neo_migrations', 'neo_schema_snapshots'], true)) {
-                continue;
-            }
-
-            $columns = $this->introspector->getColumns($table);
-            $dump[] = $table . ':' . json_encode($columns);
-        }
-
-        sort($dump);
-
-        return implode('|', $dump);
+        return json_encode(
+            $this->buildDumpArray(),
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
     }
 }

--- a/neo/Core/Database/Migration/SchemaDiffer.php
+++ b/neo/Core/Database/Migration/SchemaDiffer.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Neo\Core\Database\Migration;
+
+final class SchemaDiffer
+{
+    /**
+     * @param array<string, array<int, array<string, mixed>>> $previous
+     * @param array<string, array<int, array<string, mixed>>> $current
+     * @return array{
+     *     tablesToCreate: array<string, array<int, array<string, mixed>>>,
+     *     tablesToDrop: array<string, array<int, array<string, mixed>>>,
+     *     tableChanges: array<string, array{
+     *         added: array<int, array<string, mixed>>,
+     *         removed: array<int, array<string, mixed>>,
+     *         modified: array<int, array{before: array<string, mixed>, after: array<string, mixed>}>
+     *     }>
+     * }
+     */
+    public function diff(array $previous, array $current): array
+    {
+        $tablesToCreate = [];
+        foreach (array_diff(array_keys($current), array_keys($previous)) as $table) {
+            $tablesToCreate[$table] = $current[$table];
+        }
+
+        $tablesToDrop = [];
+        foreach (array_diff(array_keys($previous), array_keys($current)) as $table) {
+            $tablesToDrop[$table] = $previous[$table];
+        }
+
+        $tableChanges = [];
+
+        foreach ($current as $table => $columns) {
+            if (!isset($previous[$table])) {
+                continue;
+            }
+
+            $prevColumns = $this->indexByName($previous[$table]);
+            $currColumns = $this->indexByName($columns);
+
+            $added = [];
+            $removed = [];
+            $modified = [];
+
+            foreach ($currColumns as $name => $col) {
+                if (!isset($prevColumns[$name])) {
+                    $added[] = $col;
+                    continue;
+                }
+
+                if ($this->signature($prevColumns[$name]) !== $this->signature($col)) {
+                    $modified[] = ['before' => $prevColumns[$name], 'after' => $col];
+                }
+            }
+
+            foreach ($prevColumns as $name => $col) {
+                if (!isset($currColumns[$name])) {
+                    $removed[] = $col;
+                }
+            }
+
+            if ($added || $removed || $modified) {
+                $tableChanges[$table] = [
+                    'added' => $added,
+                    'removed' => $removed,
+                    'modified' => $modified,
+                ];
+            }
+        }
+
+        return [
+            'tablesToCreate' => $tablesToCreate,
+            'tablesToDrop' => $tablesToDrop,
+            'tableChanges' => $tableChanges,
+        ];
+    }
+
+    /**
+     * @param array{tablesToCreate: array<string, mixed>, tablesToDrop: array<string, mixed>, tableChanges: array<string, mixed>} $diff
+     */
+    public function isEmpty(array $diff): bool
+    {
+        return empty($diff['tablesToCreate'])
+            && empty($diff['tablesToDrop'])
+            && empty($diff['tableChanges']);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $columns
+     * @return array<string, array<string, mixed>>
+     */
+    private function indexByName(array $columns): array
+    {
+        $indexed = [];
+        foreach ($columns as $col) {
+            $indexed[$col['name']] = $col;
+        }
+        return $indexed;
+    }
+
+    /**
+     * @param array<string, mixed> $col
+     */
+    private function signature(array $col): string
+    {
+        return implode('|', [
+            (string) ($col['type'] ?? ''),
+            !empty($col['nullable']) ? '1' : '0',
+            (string) ($col['default'] ?? ''),
+            (string) ($col['extra'] ?? ''),
+            (string) ($col['key'] ?? ''),
+        ]);
+    }
+}


### PR DESCRIPTION
- MigrationSchemaSnapshot now stores/reads structured schema (table => columns) instead of an opaque hash, enabling real comparison between snapshots
- New SchemaDiffer computes tables/columns added, removed, and modified between two schema snapshots
- MigrationGenerator gains generateDiff() to produce ALTER TABLE ADD/DROP/MODIFY COLUMN statements (with reversible down()), used for every generation after the first; generate() (full CREATE TABLE dump) is now reserved for the very first migration when no snapshot exists yet
- DatabaseMigrationGenerateCommand orchestrates: full generation on first run, diff-based generation afterwards, with a readable +/-/~ summary in the console
- Also fixed the same Database/Model|Repository|Forms path bug already patched in DatabaseGenerateCommand, which this command had too

Known limitation: foreign key constraints are not captured by the introspector and therefore not part of the diff (pre-existing gap, not introduced here)