### PR TITLE
feat: column rename detection, NOT NULL safety checks, destructive co…

### DIFF
--- a/neo/Core/Database/Commands/DatabaseGenerateCommand.php
+++ b/neo/Core/Database/Commands/DatabaseGenerateCommand.php
@@ -11,6 +11,7 @@ use Neo\Core\Console\Input\InputOption;
 use Neo\Core\Console\Output\Output;
 use Neo\Core\Database\DatabaseConnection;
 use Neo\Core\Database\DatabaseIntrospector;
+use Neo\Core\Database\ORM\Model\ModelGenerator;
 use Neo\Core\Database\ORM\ORM;
 use Neo\Core\DI\Container;
 
@@ -100,7 +101,22 @@ final class DatabaseGenerateCommand extends AbstractCommand
                 force: $force,
             );
 
+
+            $modelGenerator = new ModelGenerator($this->container);
+            $validClassNames = array_map(fn($t) => $modelGenerator->resolveClassName($t), $tables);
+            $orphans = $modelGenerator->findOrphanModels($validClassNames);
+
+            if (!empty($orphans)) {
+                Output::newLine();
+                Output::warning('Orphan model files detected (table no longer exists):');
+                foreach ($orphans as $orphan) {
+                    Output::muted("  - Database/Model/{$orphan}.php");
+                }
+                Output::muted('Not deleted automatically — remove manually once you\'ve confirmed this is intentional.');
+            }
+
             Output::success("Generation completed.");
+
             return ExitCode::SUCCESS;
         } catch (\Throwable $e) {
             Output::error('Generation failed: ' . $e->getMessage());

--- a/neo/Core/Database/Commands/DatabaseMigrationGenerateCommand.php
+++ b/neo/Core/Database/Commands/DatabaseMigrationGenerateCommand.php
@@ -43,12 +43,20 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
             mode: InputOption::REQUIRED,
             description: 'Migration name slug',
         );
+
+        $this->addOption(
+            name: 'dry-run',
+            shortcut: null,
+            mode: InputOption::NONE,
+            description: 'Show the computed diff without writing a migration file',
+        );
     }
 
     public function do(Input $input, Output $output): ExitCode
     {
         $project = $input->getOption('project') ?? Input::choice('Target project ?', $this->getAvailableProjects());
         $name = $input->getOption('name') ?? Input::ask('Migration name ?', 'schema_update');
+        $dryRun = (bool) $input->getOption('dry-run');
 
         $basePath = ROOT_DIR . "/src/$project";
         $migrationsPath = "$basePath/Database/Migrations";
@@ -78,10 +86,16 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
             $db = $this->container->get(DatabaseManager::class);
             $snapshot = new MigrationSchemaSnapshot($db, $introspector);
             $generator = new MigrationGenerator($introspector);
+            $differ = new SchemaDiffer();
 
             $previousSchema = $snapshot->getLastSchema();
 
             if ($previousSchema === null) {
+                if ($dryRun) {
+                    Output::info('No previous snapshot found. Would generate a full schema migration.');
+                    return ExitCode::SUCCESS;
+                }
+
                 Output::info('No previous snapshot found. Generating full schema migration.');
                 $file = $generator->generate($migrationsPath, $name);
                 $snapshot->take();
@@ -92,8 +106,62 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
             }
 
             $currentSchema = $snapshot->getCurrentSchema();
-            $differ = new SchemaDiffer();
             $diff = $differ->diff($previousSchema, $currentSchema);
+
+            $diff['tableRenames'] = [];
+            $tableRenameCandidates = $differ->findTableRenameCandidates($diff['tablesToCreate'], $diff['tablesToDrop']);
+
+            foreach ($tableRenameCandidates as $candidate) {
+                $confirmed = $dryRun || Input::confirm(
+                        sprintf(
+                            "Table '%s' has the same structure as new table '%s'. Treat as a rename (preserves data) ?",
+                            $candidate['from'],
+                            $candidate['to']
+                        ),
+                        true
+                    );
+
+                if ($confirmed) {
+                    $diff['tableRenames'][] = $candidate;
+                    unset($diff['tablesToCreate'][$candidate['to']]);
+                    unset($diff['tablesToDrop'][$candidate['from']]);
+                }
+            }
+
+            $diff['columnRenames'] = [];
+
+            foreach ($diff['tableChanges'] as $table => $changes) {
+                $columnCandidates = $differ->findColumnRenameCandidates($changes['removed'], $changes['added']);
+
+                foreach ($columnCandidates as $candidate) {
+                    $confirmed = $dryRun || Input::confirm(
+                            sprintf(
+                                "Column '%s.%s' has the same structure as new column '%s.%s'. Treat as a rename (preserves data) ?",
+                                $table, $candidate['from'], $table, $candidate['to']
+                            ),
+                            true
+                        );
+
+                    if ($confirmed) {
+                        $diff['columnRenames'][$table][] = $candidate;
+                        $diff['tableChanges'][$table]['added'] = array_values(array_filter(
+                            $diff['tableChanges'][$table]['added'],
+                            fn($c) => $c['name'] !== $candidate['to']
+                        ));
+                        $diff['tableChanges'][$table]['removed'] = array_values(array_filter(
+                            $diff['tableChanges'][$table]['removed'],
+                            fn($c) => $c['name'] !== $candidate['from']
+                        ));
+                    }
+                }
+
+                if (empty($diff['tableChanges'][$table]['added'])
+                    && empty($diff['tableChanges'][$table]['removed'])
+                    && empty($diff['tableChanges'][$table]['modified'])
+                ) {
+                    unset($diff['tableChanges'][$table]);
+                }
+            }
 
             if ($differ->isEmpty($diff)) {
                 Output::info('No schema changes detected. Nothing to migrate.');
@@ -102,11 +170,55 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
 
             $this->printDiffSummary($diff);
 
+            $risks = $differ->findRiskyNotNullChanges($diff['tablesToCreate'], $diff['tableChanges']);
+            if (!empty($risks)) {
+                Output::newLine();
+                Output::warning('Potentially unsafe changes detected:');
+                foreach ($risks as $risk) {
+                    Output::muted(sprintf(
+                        "  ! %s.%s is NOT NULL without a default (%s) — will fail if the table already has rows.",
+                        $risk['table'], $risk['column'], $risk['context']
+                    ));
+                }
+
+                if (!$dryRun && !Input::confirm('Continue anyway ?', false)) {
+                    Output::muted('Cancelled.');
+                    return ExitCode::SUCCESS;
+                }
+            }
+
+            $hasDrops = !empty($diff['tablesToDrop']) || $this->hasColumnDrops($diff['tableChanges']);
+            if ($hasDrops && !$dryRun) {
+                Output::newLine();
+                Output::warning('This migration includes DROP operations (data loss on affected columns/tables).');
+                if (!Input::confirm('Confirm you want to proceed ?', false)) {
+                    Output::muted('Cancelled.');
+                    return ExitCode::SUCCESS;
+                }
+            }
+
+            if ($dryRun) {
+                Output::newLine();
+                Output::muted('Dry-run: no file written, no snapshot taken.');
+                return ExitCode::SUCCESS;
+            }
+
             $file = $generator->generateDiff($migrationsPath, $name, $diff);
             $snapshot->take();
 
             Output::success('Migration file generated:');
             Output::muted('  ' . str_replace(ROOT_DIR, '', $file));
+
+            if (!empty($diff['tableRenames'])) {
+                Output::newLine();
+                Output::warning('Manual follow-up required after table rename(s):');
+                foreach ($diff['tableRenames'] as $rename) {
+                    Output::muted("  - '{$rename['from']}' → '{$rename['to']}'");
+                }
+                Output::muted('  1. php bin/neo database:generate --project=' . $project . ' --only=models --force');
+                Output::muted('  2. Remove the old orphaned Model file(s) — see warnings from database:generate');
+                Output::muted('  3. Update references to the old class name(s) in repositories, Twig extensions, controllers');
+            }
 
             return ExitCode::SUCCESS;
         } catch (\Throwable $e) {
@@ -116,20 +228,46 @@ final class DatabaseMigrationGenerateCommand extends AbstractCommand
     }
 
     /**
+     * @param array<string, array{added: array<int, array<string,mixed>>, removed: array<int, array<string,mixed>>, modified: array<int, mixed>}> $tableChanges
+     */
+    private function hasColumnDrops(array $tableChanges): bool
+    {
+        foreach ($tableChanges as $changes) {
+            if (!empty($changes['removed'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param array{
      *     tablesToCreate: array<string, mixed>,
      *     tablesToDrop: array<string, mixed>,
-     *     tableChanges: array<string, array{added: array<int, array<string,mixed>>, removed: array<int, array<string,mixed>>, modified: array<int, array{before: array<string,mixed>, after: array<string,mixed>}>}>
+     *     tableChanges: array<string, array{added: array<int, array<string,mixed>>, removed: array<int, array<string,mixed>>, modified: array<int, array{before: array<string,mixed>, after: array<string,mixed>}>}>,
+     *     tableRenames?: array<int, array{from: string, to: string}>,
+     *     columnRenames?: array<string, array<int, array{from: string, to: string}>>
      * } $diff
      */
     private function printDiffSummary(array $diff): void
     {
+        foreach ($diff['tableRenames'] ?? [] as $rename) {
+            Output::info("  ~ table `{$rename['from']}` → `{$rename['to']}` (rename)");
+        }
+
         foreach (array_keys($diff['tablesToCreate']) as $table) {
             Output::success("  + table `$table`");
         }
 
         foreach (array_keys($diff['tablesToDrop']) as $table) {
             Output::warning("  - table `$table`");
+        }
+
+        foreach ($diff['columnRenames'] ?? [] as $table => $renames) {
+            foreach ($renames as $rename) {
+                Output::info("  ~ {$table}.{$rename['from']} → {$table}.{$rename['to']} (rename)");
+            }
         }
 
         foreach ($diff['tableChanges'] as $table => $changes) {

--- a/neo/Core/Database/Migration/MigrationGenerator.php
+++ b/neo/Core/Database/Migration/MigrationGenerator.php
@@ -44,17 +44,22 @@ final class MigrationGenerator
      * @param array{
      *     tablesToCreate: array<string, array<int, array<string, mixed>>>,
      *     tablesToDrop: array<string, array<int, array<string, mixed>>>,
-     *     tableChanges: array<string, array{
-     *         added: array<int, array<string, mixed>>,
-     *         removed: array<int, array<string, mixed>>,
-     *         modified: array<int, array{before: array<string, mixed>, after: array<string, mixed>}>
-     *     }>
+     *     tableChanges: array<string, array{added: array<int, array<string,mixed>>, removed: array<int, array<string,mixed>>, modified: array<int, array{before: array<string,mixed>, after: array<string,mixed>}>}>,
+     *     tableRenames?: array<int, array{from: string, to: string}>,
+     *     columnRenames?: array<string, array<int, array{from: string, to: string}>>
      * } $diff
      */
     public function generateDiff(string $migrationsPath, string $name, array $diff): string
     {
         $upLines = [];
         $downLines = [];
+
+        foreach ($diff['tableRenames'] ?? [] as $rename) {
+            $from = $rename['from'];
+            $to = $rename['to'];
+            $upLines[] = $this->executeLine("RENAME TABLE `$from` TO `$to`");
+            $downLines[] = $this->executeLine("RENAME TABLE `$to` TO `$from`");
+        }
 
         foreach ($diff['tablesToCreate'] as $table => $columns) {
             $upLines[] = $this->executeLine($this->buildCreateTableSql($table, $columns));
@@ -64,6 +69,13 @@ final class MigrationGenerator
         foreach ($diff['tablesToDrop'] as $table => $columns) {
             $upLines[] = $this->executeLine("DROP TABLE IF EXISTS `$table`");
             $downLines[] = $this->executeLine($this->buildCreateTableSql($table, $columns));
+        }
+
+        foreach ($diff['columnRenames'] ?? [] as $table => $renames) {
+            foreach ($renames as $rename) {
+                $upLines[] = $this->executeLine("ALTER TABLE `$table` RENAME COLUMN `{$rename['from']}` TO `{$rename['to']}`");
+                $downLines[] = $this->executeLine("ALTER TABLE `$table` RENAME COLUMN `{$rename['to']}` TO `{$rename['from']}`");
+            }
         }
 
         foreach ($diff['tableChanges'] as $table => $changes) {

--- a/neo/Core/Database/Migration/SchemaDiffer.php
+++ b/neo/Core/Database/Migration/SchemaDiffer.php
@@ -84,7 +84,103 @@ final class SchemaDiffer
     {
         return empty($diff['tablesToCreate'])
             && empty($diff['tablesToDrop'])
-            && empty($diff['tableChanges']);
+            && empty($diff['tableChanges'])
+            && empty($diff['tableRenames']);
+    }
+
+    /**
+     * @param array<string, array<int, array<string, mixed>>> $tablesToCreate
+     * @param array<string, array<int, array<string, mixed>>> $tablesToDrop
+     * @return array<int, array{from: string, to: string}>
+     */
+    public function findTableRenameCandidates(array $tablesToCreate, array $tablesToDrop): array
+    {
+        $dropSignatures = [];
+        foreach ($tablesToDrop as $table => $columns) {
+            $dropSignatures[$this->buildTableSignature($columns)][] = $table;
+        }
+
+        $createSignatures = [];
+        foreach ($tablesToCreate as $table => $columns) {
+            $createSignatures[$this->buildTableSignature($columns)][] = $table;
+        }
+
+        $candidates = [];
+
+        foreach ($dropSignatures as $signature => $droppedTables) {
+            if (count($droppedTables) !== 1 || empty($createSignatures[$signature]) || count($createSignatures[$signature]) !== 1) {
+                continue; // ambiguous match on either side, skip
+            }
+
+            $candidates[] = [
+                'from' => $droppedTables[0],
+                'to' => $createSignatures[$signature][0],
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $removed
+     * @param array<int, array<string, mixed>> $added
+     * @return array<int, array{from: string, to: string}>
+     */
+    public function findColumnRenameCandidates(array $removed, array $added): array
+    {
+        $removedBySignature = [];
+        foreach ($removed as $col) {
+            $removedBySignature[$this->signature($col)][] = $col['name'];
+        }
+
+        $addedBySignature = [];
+        foreach ($added as $col) {
+            $addedBySignature[$this->signature($col)][] = $col['name'];
+        }
+
+        $candidates = [];
+
+        foreach ($removedBySignature as $signature => $names) {
+            if (count($names) !== 1 || empty($addedBySignature[$signature]) || count($addedBySignature[$signature]) !== 1) {
+                continue;
+            }
+
+            $candidates[] = [
+                'from' => $names[0],
+                'to' => $addedBySignature[$signature][0],
+            ];
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param array<string, array<int, array<string, mixed>>> $tablesToCreate
+     * @param array<string, array{added: array<int, array<string,mixed>>, removed: array<int, array<string,mixed>>, modified: array<int, array{before: array<string,mixed>, after: array<string,mixed>}>}> $tableChanges
+     * @return array<int, array{table: string, column: string, context: string}>
+     */
+    public function findRiskyNotNullChanges(array $tablesToCreate, array $tableChanges): array
+    {
+        $risks = [];
+
+        foreach ($tableChanges as $table => $changes) {
+            foreach ($changes['added'] as $col) {
+                if (empty($col['nullable']) && $col['default'] === null && !$this->isAutoIncrementPrimary($col)) {
+                    $risks[] = ['table' => $table, 'column' => $col['name'], 'context' => 'added'];
+                }
+            }
+
+            foreach ($changes['modified'] as $change) {
+                $before = $change['before'];
+                $after = $change['after'];
+
+                if (!empty($before['nullable']) && empty($after['nullable']) && $after['default'] === null) {
+                    $risks[] = ['table' => $table, 'column' => $after['name'], 'context' => 'modified'];
+                }
+            }
+        }
+
+        return $risks;
     }
 
     /**
@@ -112,5 +208,30 @@ final class SchemaDiffer
             (string) ($col['extra'] ?? ''),
             (string) ($col['key'] ?? ''),
         ]);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $columns
+     */
+    private function buildTableSignature(array $columns): string
+    {
+        $parts = [];
+
+        foreach ($columns as $col) {
+            $parts[$col['name']] = $col['name'] . ':' . $this->signature($col);
+        }
+
+        ksort($parts);
+
+        return implode('|', $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $col
+     */
+    private function isAutoIncrementPrimary(array $col): bool
+    {
+        return ($col['key'] ?? '') === 'PRI'
+            && str_contains(strtolower((string) ($col['extra'] ?? '')), 'auto_increment');
     }
 }

--- a/neo/Core/Database/ORM/Model/ModelGenerator.php
+++ b/neo/Core/Database/ORM/Model/ModelGenerator.php
@@ -350,4 +350,32 @@ PHP;
             )
         );
     }
+
+    public function resolveClassName(string $table): string
+    {
+        $tableWithoutPrefix = ($this->prefix !== '' && str_starts_with($table, $this->prefix))
+            ? substr($table, strlen($this->prefix))
+            : $table;
+
+        return $this->convertToClassName($tableWithoutPrefix);
+    }
+
+    /**
+     * @param array<int, string> $validClassNames
+     * @return array<int, string>
+     */
+    public function findOrphanModels(array $validClassNames): array
+    {
+        $orphans = [];
+
+        foreach (glob($this->modelDir . '/*.php') ?: [] as $file) {
+            $className = basename($file, '.php');
+
+            if (!in_array($className, $validClassNames, true)) {
+                $orphans[] = $className;
+            }
+        }
+
+        return $orphans;
+    }
 }


### PR DESCRIPTION
…nfirmations, dry-run, orphan model detection

- SchemaDiffer: detect column renames within a table (same signature, unambiguous match), and flag NOT NULL columns added/changed without a default (would fail ALTER on non-empty tables)
- MigrationGenerator: generate RENAME COLUMN statements for confirmed column renames, reversible via down()
- DatabaseMigrationGenerateCommand: confirm column renames individually, warn and require explicit confirmation before any DROP TABLE/COLUMN, warn on risky NOT NULL changes with opt-out, add --dry-run to preview the diff without writing a file or taking a snapshot, print a manual follow-up checklist after table renames (regenerate models, remove orphan files, update code references)
- ModelGenerator: add resolveClassName() and findOrphanModels() to detect Model files left behind after a table rename/removal
- DatabaseGenerateCommand: surface orphan model warnings after generation

Known limitation: code-level renaming (class names, use statements, repository references) remains manual — automating that safely would require proper static analysis (e.g. Rector), out of scope here.