### PR TITLE
fix: preserve pascalCase segments and prioritize HTTP_HOST for projec…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,11 @@
         "psr-4": {
             "Neo\\": "neo/",
             "Neo\\Src\\": "src/"
-        }
+        },
+        "exclude-from-classmap": [
+            "/src/*/Database/Migrations/",
+            "/src/*/Storage/"
+        ]
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/neo/Core/Application/ApplicationDetector.php
+++ b/neo/Core/Application/ApplicationDetector.php
@@ -68,7 +68,7 @@ class ApplicationDetector
         $request = $this->container->get(Request::class);
         $serverData = $request->getServer() ?? $_SERVER;
 
-        $serverName = $serverData['SERVER_NAME'] ?? $serverData['HTTP_HOST'] ?? null;
+        $serverName = $serverData['HTTP_HOST'] ?? $serverData['SERVER_NAME'] ?? null;
         $serverPort = (string) ($serverData['SERVER_PORT'] ?? '');
 
         if (!$serverName) {
@@ -80,7 +80,7 @@ class ApplicationDetector
         }
 
         $server = $serverName;
-        if (!empty($serverPort) && !in_array($serverPort, ['80', '443'])) {
+        if (!str_contains($server, ':') && !empty($serverPort) && !in_array($serverPort, ['80', '443'])) {
             $server .= ':' . $serverPort;
         }
 
@@ -88,7 +88,7 @@ class ApplicationDetector
             $config = require $file;
             $accessServer = $config['access'] ?? null;
 
-            if ($accessServer === $server || $accessServer === $serverName) {
+            if ($accessServer === $server) {
                 $this->container->set('application', basename(dirname($file, 2)));
                 return;
             }

--- a/neo/Core/Console/Helper/Fs.php
+++ b/neo/Core/Console/Helper/Fs.php
@@ -61,26 +61,27 @@ final class Fs
 
     public static function pascalCase(string $string): string
     {
-        $string = preg_replace('/(?<=[a-z0-9])(?=[A-Z])/', ' ', $string);
         $string = self::stripAccents($string);
-        $string = str_replace('-', '_', $string);
-        $string = preg_replace('/[^a-zA-Z0-9_\s]+/', ' ', $string);
+        $string = str_replace(['-', ' '], '_', $string);
+        $string = preg_replace('/[^A-Za-z0-9_]+/', '', $string);
+        $string = trim($string, '_');
 
-        $tokens = array_filter(explode(' ', trim($string)), fn($t) => $t !== '');
-
-        $result = '';
-        foreach ($tokens as $token) {
-            $parts = explode('_', $token);
-            $parts = array_map(
-                fn($part) => $part === ''
-                    ? ''
-                    : mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1),
-                $parts
-            );
-            $result .= implode('', $parts);
+        if ($string === '') {
+            return '';
         }
 
-        return $result;
+        if (!str_contains($string, '_')) {
+            return mb_strtoupper(mb_substr($string, 0, 1)) . mb_substr($string, 1);
+        }
+
+        $parts = array_filter(explode('_', $string), fn($p) => $p !== '');
+
+        $parts = array_map(
+            fn($part) => mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1),
+            $parts
+        );
+
+        return implode('_', $parts);
     }
 
     private static function stripAccents(string $string): string


### PR DESCRIPTION
…t detection

pascalCase() (Fs.php):
- Input containing '_' or '-' (normalized to '_'): capitalize only the first letter of each segment, keep the rest as-is, preserve '_' as separator (AML_Store -> AML_Store, AML-Store -> AML_Store, aml-store -> Aml_Store)
- Input with no separator (pure camelCase): capitalize only the first letter (amlStore -> AmlStore)
- Previously all input was merged into a single PascalCase token regardless of separator, losing the snake_case vs camelCase distinction. Affects every command using Fs::pascalCase() (project:create, make:controller, make:crud, make:event, etc.)

ApplicationDetector (detectFromHttp):
- Prioritize HTTP_HOST over SERVER_NAME when resolving the current project from the request. With PHP's built-in server (php -S), SERVER_NAME reflects the hostname the server was started with and stays frozen across every request it serves, while HTTP_HOST correctly reflects the real Host header per-request — this broke multi-subdomain testing where several projects share the same port (e.g. aml.localhost:8000 and store.aml.localhost:8000 on one process)
- Avoid double-appending the port when HTTP_HOST already includes it